### PR TITLE
fix(deps): 脆弱な推移的依存を更新しDependabot alertsを解消 (ws, qs, path-to-regexp)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1437,8 +1437,8 @@ packages:
   path-to-glob-pattern@2.0.1:
     resolution: {integrity: sha512-tmciSlVyHnX0LC86+zSr+0LURw9rDPw8ilhXcmTpVUOnI6OsKdCzXQs5fTG10Bjz26IBdnKL3XIaP+QvGsk5YQ==}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1481,8 +1481,8 @@ packages:
     resolution: {integrity: sha512-+Owyggi9IxT1ePKGafcI87ubSmxol6smwJ+RAHDQlx9+9cPwFWDiKFFCPuWhr9ignlGpZ9vDQLw67N4dcTVFEA==}
     engines: {node: '>=20'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -1972,8 +1972,8 @@ packages:
   write-file-atomic@1.3.4:
     resolution: {integrity: sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==}
 
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2123,7 +2123,7 @@ snapshots:
       express: 5.2.1
       gray-matter: 4.0.3
       open: 10.2.0
-      ws: 8.19.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -2453,7 +2453,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -2796,7 +2796,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -3790,7 +3790,7 @@ snapshots:
 
   path-to-glob-pattern@2.0.1: {}
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   picocolors@1.1.1: {}
 
@@ -3825,7 +3825,7 @@ snapshots:
     dependencies:
       hookified: 2.2.0
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -3937,7 +3937,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4613,7 +4613,7 @@ snapshots:
       imurmurhash: 0.1.4
       slide: 1.1.6
 
-  ws@8.19.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
## 概要

現在openになっている **Dependabot alerts 4件** を解消します。すべて devDependency である `@qiita/qiita-cli@1.8.0`（`pnpm preview` 用・最新版）の**推移的依存**で、`pnpm-lock.yaml` 内のバージョンが古いまま残っていたことが原因です。

親パッケージの許容範囲は既にパッチ版を許容しているため、`package.json` は変更せず **`pnpm-lock.yaml` のみを更新**しています。

## 解消するalertと対応バージョン

| Alert | パッケージ | 変更 | 深刻度 | 内容 | 依存チェーン |
|---|---|---|---|---|---|
| #46 | path-to-regexp | 8.3.0 → 8.4.2 | **high** | ReDoS (sequential optional groups) | qiita-cli → express → router |
| #47 | path-to-regexp | 8.3.0 → 8.4.2 | medium | ReDoS (multiple wildcards) | 同上 |
| #65 | qs | 6.15.0 → 6.15.2 | medium | DoS (qs.stringify) | qiita-cli → express |
| #66 | ws | 8.19.0 → 8.21.0 | medium | Uninitialized memory disclosure | qiita-cli → ws |

## 親パッケージの許容範囲（パッチ版を許容済み）

- `express@5.2.1` → `qs: ^6.14.0`（6.15.2 を許容）
- `router@2.2.0` → `path-to-regexp: ^8.0.0`（8.4.2 を許容）
- `@qiita/qiita-cli@1.8.0` → `ws: ^8.18.3`（8.21.0 を許容）

## 影響範囲

- 変更はすべて **devDependency 配下のパッチバージョンアップ**で、ローカルプレビュー（`pnpm preview`）でのみ使用されます。公開記事（`public/`）には影響しません。
- breaking change のリスクは低い（いずれもパッチレベルの更新）。

## 確認したこと

- `git diff` の変更は `pnpm-lock.yaml` のみ（`package.json` は無変更）
- `pnpm run lint:md` → 0 error
- `pnpm run lint:text` → 問題なし
- `pnpm run validate` → 問題なし

> Dependabot alerts は本PRが `master` にマージされた後にcloseされます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)