### PR TITLE
chore(renovate): mise マネージャ有効化と脆弱性・ノイズ制御を拡充

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,38 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "enabledManagers": ["npm", "github-actions"],
+  "extends": ["config:recommended", "schedule:weekly"],
+  "timezone": "Asia/Tokyo",
+  "enabledManagers": ["npm", "github-actions", "mise"],
+  "labels": ["dependencies"],
+  "osvVulnerabilityAlerts": true,
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "description": "CI 通過後に minor/patch/pin/digest を自動マージ",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "description": "node は LTS のみ（node versioning が奇数=unstable を除外）",
+      "matchDatasources": ["node-version"],
+      "matchPackageNames": ["node"],
+      "versioning": "node"
+    },
+    {
+      "description": "pnpm を mise.toml と packageManager でまとめて更新",
+      "matchPackageNames": ["pnpm"],
+      "groupName": "pnpm"
+    },
+    {
+      "description": "GitHub Actions をまとめて更新",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "description": "textlint 関連パッケージをまとめて更新",
+      "matchPackageNames": ["/^textlint/"],
+      "groupName": "textlint"
     }
   ]
 }


### PR DESCRIPTION
## 概要

Dependabot → Renovate 移行後の最小構成だった `.github/renovate.json` を拡充し、(1) ランタイム更新の自動化、(2) 脆弱性駆動の自動 PR、(3) 週次・エコシステム別のノイズ制御を導入する。変更は `.github/renovate.json` の1ファイルのみ。

## 変更内容

- **`mise` マネージャを有効化** — これまで管理外だった `mise.toml` の node/pnpm を自動更新化。node は node versioning + `ignoreUnstable`(既定) により **LTS 系統に自動限定**（脆弱な `allowedVersions` 正規表現は不使用、`versioning: "node"` を明示）
- **`osvVulnerabilityAlerts: true`** — 既知脆弱性（transitive 含む）を OSV/OpenSSF feed で検知し PR 自動化。直近の手動修正（`f59b0e4`: ws/qs/path-to-regexp）を自動化
- **`minimumReleaseAge: "3 days"` + `internalChecksFilter: "strict"`** — 公開3日未満の新版を直接依存の更新対象から除外（アカウント乗っ取り直後の悪性版を回避）
- **`schedule:weekly` + `timezone: "Asia/Tokyo"`** — 週次バッチで PR ノイズ削減（OSV/セキュリティ PR はスケジュール無視で随時）
- **グルーピング** — pnpm（`mise.toml` と `packageManager` を集約）/ github-actions / textlint をエコシステム別の分割 PR に
- **`labels: ["dependencies"]`** を付与

既存ルール（minor/patch/pin/digest は CI 通過後に自動マージ・major は手動）は維持。`renovate-config-validator` で検証済み（`Config validated successfully`）。

## 補足（コードで完結しない手動設定）

automerge を有効化するには GitHub 側で **"Allow auto-merge" を ON** + **`master` の branch protection に required status check（lint / validate）** が必要。

## 見送り

- `lockFileMaintenance`: lock 全体再生成で transitive 脆弱性を再混入し得る（抑止は pnpm 11.5.1 の1日 floor 頼み、Renovate の `minimumReleaseAge` は lock 再生成をガードしない / renovate#38115）。OSV による既知脆弱性のピンポイント修正の方が低リスクのため不採用。

---
このPRは `/quick-pr` で自動生成されました
