### PR TITLE
ci: Qiitaトークンの有効性チェックワークフローを追加

### DIFF
--- a/.github/workflows/check-qiita-token.yml
+++ b/.github/workflows/check-qiita-token.yml
@@ -3,6 +3,9 @@ name: Check Qiita token
 on:
   schedule:
     - cron: '30 21 * * *' # 6:30 JST（sync の30分前）
+  pull_request:
+    paths:
+      - .github/workflows/check-qiita-token.yml
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/check-qiita-token.yml
+++ b/.github/workflows/check-qiita-token.yml
@@ -1,0 +1,32 @@
+name: Check Qiita token
+
+on:
+  schedule:
+    - cron: '30 21 * * *' # 6:30 JST（sync の30分前）
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check_qiita_token:
+    runs-on: ubuntu-slim # 1 vCPU 軽量ランナー（public preview）。不安定なら ubuntu-latest に戻す
+    timeout-minutes: 5
+    steps:
+      - name: Check Qiita token validity
+        env:
+          QIITA_TOKEN: ${{ secrets.QIITA_TOKEN }}
+        run: |
+          if [ -z "$QIITA_TOKEN" ]; then
+            echo "::error::QIITA_TOKEN secret が未設定です。"
+            exit 1
+          fi
+          status=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer ${QIITA_TOKEN}" \
+            https://qiita.com/api/v2/authenticated_user)
+          if [ "$status" -ne 200 ]; then
+            echo "::error::Qiita トークンチェック失敗 (HTTP ${status})。"
+            echo "::error::https://qiita.com/settings/applications で read_qiita スコープ付きトークンを再発行し、Secrets の QIITA_TOKEN を更新してください。"
+            exit 1
+          fi
+          echo "Qiita トークンは有効です (HTTP 200)。"

--- a/.github/workflows/check-qiita-token.yml
+++ b/.github/workflows/check-qiita-token.yml
@@ -26,8 +26,8 @@ jobs:
           fi
           status=$(curl -sS -o /dev/null -w '%{http_code}' \
             -H "Authorization: Bearer ${QIITA_TOKEN}" \
-            https://qiita.com/api/v2/authenticated_user)
-          if [ "$status" -ne 200 ]; then
+            https://qiita.com/api/v2/authenticated_user) || status="000"
+          if [ "$status" != "200" ]; then
             echo "::error::Qiita トークンチェック失敗 (HTTP ${status})。"
             echo "::error::https://qiita.com/settings/applications で read_qiita スコープ付きトークンを再発行し、Secrets の QIITA_TOKEN を更新してください。"
             exit 1


### PR DESCRIPTION
## 背景

「Sync remote and create PR」ワークフローが 6/3・6/4 と連続で失敗していた。
原因は `pnpm exec qiita pull` 実行時に Qiita API が **403 Forbidden** を返す認証エラー
（`QiitaForbiddenError`）で、`QIITA_TOKEN` シークレットが失効したと考えられる。

トークン失効は実際に sync が走るまで気づけないため、**事前に検知できる専用の軽量 CI** を追加する。

## 変更内容

- `.github/workflows/check-qiita-token.yml` を新規追加

## 動作仕様

| 項目 | 内容 |
|------|------|
| 実行タイミング | 毎日 6:30 JST（sync の30分前）+ 手動 (`workflow_dispatch`) |
| 確認方法 | `GET /api/v2/authenticated_user` を curl で直接叩き、HTTP 200 を確認 |
| 異常検知時 | CI failure + エラーメッセージにトークン再発行 URL を表示 |
| runner | `ubuntu-slim`（1 vCPU / 5GB、curl のみで十分） |

## トークン失効時の対応手順（失敗時メッセージにも記載）

1. https://qiita.com/settings/applications で `read_qiita` スコープ付きトークンを再発行
2. このリポジトリの Settings → Secrets → Actions で `QIITA_TOKEN` を更新
3. sync ワークフローを Re-run して復旧確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)