### PR TITLE
fix(deps): hono を 4.12.23 に更新し脆弱性 alert を解消

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -804,8 +804,8 @@ packages:
   hastscript@5.1.2:
     resolution: {integrity: sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==}
 
-  hono@4.12.19:
-    resolution: {integrity: sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   hookified@1.15.1:
@@ -2045,9 +2045,9 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@hono/node-server@1.19.14(hono@4.12.19)':
+  '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
-      hono: 4.12.19
+      hono: 4.12.23
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
@@ -2080,7 +2080,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.19)
+      '@hono/node-server': 1.19.14(hono@4.12.23)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -2090,7 +2090,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.19
+      hono: 4.12.23
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3000,7 +3000,7 @@ snapshots:
       property-information: 5.6.0
       space-separated-tokens: 1.1.5
 
-  hono@4.12.19: {}
+  hono@4.12.23: {}
 
   hookified@1.15.1: {}
 


### PR DESCRIPTION
## 概要

推移的依存の `hono` を 4.12.19 → 4.12.23 に更新し、オープン中の Dependabot alert 4 件を解消します。`pnpm-lock.yaml` のみの変更です。

`hono` は `textlint` → `@modelcontextprotocol/sdk` → `@hono/node-server`（および `@modelcontextprotocol/sdk` から直接）経由の推移的依存で、依存元の許容範囲は `^4` / `^4.11.4` のため lockfile 更新のみで解消できます。

## 解消する alert（すべて severity: medium、4.12.21 で修正済み）

| # | GHSA | 概要 |
|---|------|------|
| #70 | GHSA-3hrh-pfw6-9m5x | Cookie helper が sameSite/priority を未サニタイズ（Set-Cookie injection） |
| #69 | GHSA-xrhx-7g5j-rcj5 | IP 制限が非正規 IPv6 で deny ルールを回避 |
| #68 | GHSA-2gcr-mfcq-wcc3 | app.mount() が percent-encoded パスで誤ルーティング |
| #67 | GHSA-f577-qrjj-4474 | JWT middleware が Bearer 以外の Authorization scheme も受理 |

## 確認

- [x] `pnpm why hono` → 4.12.23
- [x] `pnpm install --frozen-lockfile` 成功
- [x] `pnpm run lint:md` pass
- [x] `pnpm run validate` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)