### PR TITLE
chore(renovate): 脆弱性アラートの remediation を強化

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,12 @@
   "enabledManagers": ["npm", "github-actions", "mise"],
   "labels": ["dependencies"],
   "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": true,
+    "minimumReleaseAge": null
+  },
+  "transitiveRemediation": true,
   "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
   "packageRules": [


### PR DESCRIPTION
## 概要

Renovate の脆弱性対応を強化します。今回 hono の Dependabot alert が Renovate で自動修正されなかった主因は「推移的依存の remediation が既定で無効」だったためです。これを踏まえて設定を追加します。

## 変更内容（`.github/renovate.json`）

```diff
   "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": true,
+    "minimumReleaseAge": null
+  },
+  "transitiveRemediation": true,
   "minimumReleaseAge": "3 days",
```

- **`vulnerabilityAlerts`**: 脆弱性修正 PR に `security` ラベルを付与、automerge を有効化、`minimumReleaseAge` を `null` にして待機なしで即時対応
- **`transitiveRemediation`**: 推移的依存（今回の hono のようなケース）も remediation 対象にする（npm 対象）

## 補足

GitHub 側の Dependabot security updates 有効化はバックアップとして有効ですが、Renovate と PR が二重に出る可能性があるため本 PR には含めていません。必要なら別途検討してください。

## 確認

- [x] `JSON.parse` 成功
- [x] `renovate-config-validator` で `Config validated successfully`

🤖 Generated with [Claude Code](https://claude.com/claude-code)